### PR TITLE
Remove redundant constraint

### DIFF
--- a/app/src/main/res/layout/activity_pdf_viewer.xml
+++ b/app/src/main/res/layout/activity_pdf_viewer.xml
@@ -103,7 +103,6 @@
             android:textSize="20sp"
             android:textStyle="normal"
             android:visibility="gone"
-            app:layout_constraintEnd_toStartOf="@+id/buttonFullScreenToolbar"
             app:layout_constraintStart_toEndOf="@+id/buttonGoBackToolbar"
             app:layout_constraintTop_toTopOf="@+id/toolbar"
             tools:ignore="RtlCompat" />


### PR DESCRIPTION
Otherwise, the app does not build [on F-Droid](https://gitlab.com/austinhuang0131/fdroiddata/-/jobs/1669947421) or on my local Android Studio:

```
> Task :app:lintVitalRelease
/home/vagrant/build/com.saverio.pdfviewer/app/src/main/res/layout/activity_pdf_viewer.xml:106: Error: @+id/buttonFullScreenToolbar is not a sibling in the same ConstraintLayout [NotSibling]
            app:layout_constraintEnd_toStartOf="@+id/buttonFullScreenToolbar"
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   Explanation for issues of type "NotSibling":
   Layout constraints in a given ConstraintLayout or RelativeLayout should
   reference other views within the same relative layout (but not itself!)
```

Tested and it does not seem to hurt the layout.

Please re-release afterwards.